### PR TITLE
fix: Seaport address + Seaport version

### DIFF
--- a/references/marketplace-api.md
+++ b/references/marketplace-api.md
@@ -357,7 +357,7 @@ POST /api/v2/orders/chain/{chain}/protocol/{protocol_address}/hash/{order_hash}/
 
 | Chain | Seaport 1.6 Address |
 |-------|---------------------|
-| All chains | `0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC` |
+| All chains | `0x0000000000000068F116a894984e2DB1123eB395` |
 
 ---
 

--- a/references/seaport.md
+++ b/references/seaport.md
@@ -13,7 +13,7 @@ Seaport is the marketplace protocol used for OpenSea orders. All listings and of
 |-------|---------------------|
 | All EVM chains | `0x0000000000000068F116a894984e2DB1123eB395` |
 
-Legacy Seaport 1.4: `0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC`
+Legacy Seaport 1.5: `0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC`
 
 ---
 


### PR DESCRIPTION
# Description
While reading the documentation, I found some minor errors:
1. The [marketplace-api](https://github.com/ProjectOpenSea/opensea-skill/blob/main/references/marketplace-api.md) file contains an incorrect address for Seaport v1.6:
<img width="484" height="169" alt="image" src="https://github.com/user-attachments/assets/25923b1c-9f59-4d5d-a3e7-8c6e59e30b15" />
<img width="583" height="459" alt="image" src="https://github.com/user-attachments/assets/01281a96-2cf3-4a1d-a0b3-0c55cfe44f43" />

2. The [seaport.md](https://github.com/ProjectOpenSea/opensea-skill/blob/main/references/seaport.md) file incorrectly specifies the previous version (1.4), although the current version is 1.6 and the previous version is 1.5.