### PR TITLE
fix: update Seaport protocol address from v1.4 to v1.6

### DIFF
--- a/references/marketplace-api.md
+++ b/references/marketplace-api.md
@@ -139,7 +139,7 @@ GET /api/v2/orders/chain/{chain}/protocol/{protocol_address}/hash/{order_hash}
 
 **Example:**
 ```bash
-scripts/opensea-get.sh "/api/v2/orders/chain/ethereum/protocol/0x00000000000000adc04c56bf30ac9d3c0aaf14dc/hash/0x..."
+scripts/opensea-get.sh "/api/v2/orders/chain/ethereum/protocol/0x0000000000000068f116a894984e2db1123eb395/hash/0x..."
 ```
 
 ---
@@ -248,7 +248,7 @@ POST /api/v2/listings/fulfillment_data
   "listing": {
     "hash": "0xOrderHash",
     "chain": "ethereum",
-    "protocol_address": "0x00000000000000adc04c56bf30ac9d3c0aaf14dc"
+    "protocol_address": "0x0000000000000068f116a894984e2db1123eb395"
   },
   "fulfiller": {
     "address": "0xBuyerWalletAddress"
@@ -272,7 +272,7 @@ POST /api/v2/offers/fulfillment_data
   "offer": {
     "hash": "0xOfferOrderHash",
     "chain": "ethereum",
-    "protocol_address": "0x00000000000000adc04c56bf30ac9d3c0aaf14dc"
+    "protocol_address": "0x0000000000000068f116a894984e2db1123eb395"
   },
   "fulfiller": {
     "address": "0xSellerWalletAddress"
@@ -357,7 +357,7 @@ POST /api/v2/orders/chain/{chain}/protocol/{protocol_address}/hash/{order_hash}/
 
 | Chain | Seaport 1.6 Address |
 |-------|---------------------|
-| All chains | `0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC` |
+| All chains | `0x0000000000000068F116a894984e2DB1123eB395` |
 
 ---
 

--- a/scripts/opensea-fulfill-listing.sh
+++ b/scripts/opensea-fulfill-listing.sh
@@ -11,7 +11,7 @@ fi
 chain="$1"
 order_hash="$2"
 fulfiller="$3"
-protocol="0x00000000000000adc04c56bf30ac9d3c0aaf14dc"
+protocol="0x0000000000000068f116a894984e2db1123eb395"
 
 body=$(cat <<EOF
 {

--- a/scripts/opensea-fulfill-offer.sh
+++ b/scripts/opensea-fulfill-offer.sh
@@ -13,7 +13,7 @@ order_hash="$2"
 fulfiller="$3"
 contract="$4"
 token_id="$5"
-protocol="0x00000000000000adc04c56bf30ac9d3c0aaf14dc"
+protocol="0x0000000000000068f116a894984e2db1123eb395"
 
 body=$(cat <<EOF
 {

--- a/scripts/opensea-order.sh
+++ b/scripts/opensea-order.sh
@@ -9,6 +9,6 @@ fi
 
 chain="$1"
 order_hash="$2"
-protocol="0x00000000000000adc04c56bf30ac9d3c0aaf14dc"
+protocol="0x0000000000000068f116a894984e2db1123eb395"
 
 "$(dirname "$0")/opensea-get.sh" "/api/v2/orders/chain/${chain}/protocol/${protocol}/${order_hash}"


### PR DESCRIPTION
# fix: update Seaport protocol address from v1.4 to v1.6

## Summary

All shell scripts and `marketplace-api.md` examples were hardcoding the Seaport **v1.4** contract address (`0x00000000000000adc04c56bf30ac9d3c0aaf14dc`) despite the rest of the documentation (e.g. `references/seaport.md`) already referencing Seaport **v1.6** (`0x0000000000000068f116a894984e2db1123eb395`).

This PR updates the protocol address to v1.6 in:
- `scripts/opensea-fulfill-listing.sh`
- `scripts/opensea-fulfill-offer.sh`
- `scripts/opensea-order.sh`
- `references/marketplace-api.md` (examples + address table)

Context: prompted by reviewing external PR #1 which identified the address table bug in `marketplace-api.md`. That PR also incorrectly relabeled the legacy address from "Seaport 1.4" to "Seaport 1.5" — that change is **not** included here since the address is genuinely the v1.4 contract.

**Confidence: 🟡 MEDIUM** — The v1.6 address matches what `seaport.md` already documents and what the code examples in that file use, but I have not tested these scripts against the live API.

## Review & Testing Checklist for Human

- [x] **Verify the Seaport v1.6 address is correct** — confirm `0x0000000000000068f116a894984e2db1123eb395` on [Etherscan](https://etherscan.io/address/0x0000000000000068f116a894984e2db1123eb395) or the [Seaport repo](https://github.com/ProjectOpenSea/seaport). This is the highest-risk item.
- [x] **Confirm no legacy v1.4 orders still need to be fulfilled** — switching exclusively to v1.6 means the scripts can no longer query or fulfill orders created under v1.4. Verify this is acceptable.
- [x] **Test at least one script against the live API** — e.g. run `opensea-order.sh` with a known v1.6 order hash to confirm the updated protocol address works end-to-end.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/9a70b3093d2d42a6a13e59f8eebcc0ac
- Requested by: @ckorhonen