### PR TITLE
feat: add User-Agent header to curl-based shell scripts [DIS-43]

### DIFF
--- a/scripts/opensea-get.sh
+++ b/scripts/opensea-get.sh
@@ -22,4 +22,4 @@ if [ -n "$query" ]; then
   url="$url?$query"
 fi
 
-curl -sS -H "x-api-key: $key" "$url"
+curl -sS -H "x-api-key: $key" -H "User-Agent: opensea-skill/1.0" "$url"

--- a/scripts/opensea-post.sh
+++ b/scripts/opensea-post.sh
@@ -21,6 +21,7 @@ url="$base$path"
 
 curl -sS -X POST \
   -H "x-api-key: $key" \
+  -H "User-Agent: opensea-skill/1.0" \
   -H "Content-Type: application/json" \
   -d "$body" \
   "$url"


### PR DESCRIPTION
## Summary

Adds `User-Agent: opensea-skill/1.0` header to all curl-based API calls by modifying the two shared HTTP transport scripts (`opensea-get.sh` and `opensea-post.sh`). All other curl-based scripts in the repo delegate to these two files, so this single change point covers every REST API call.

Scripts that don't use curl (`opensea-swap.sh` via mcporter, `opensea-stream-collection.sh` via websocat) are unaffected and out of scope.

**Confidence: 🟢 HIGH** — minimal, mechanical change with clear scope.

## Review & Testing Checklist for Human

- [ ] Verify `opensea-skill/1.0` is the desired User-Agent string for backend tracking/analytics
- [ ] Quick smoke test: run `bash -x scripts/opensea-collection.sh <slug>` (with a valid API key) and confirm `User-Agent: opensea-skill/1.0` appears in the curl invocation

### Notes

- [Linear ticket: DIS-43](https://linear.app/opensea/issue/DIS-43/tracking-add-user-agent-header-to-opensea-skill-shell-scripts)
- [Devin session](https://app.devin.ai/sessions/e0340ccc2f9f469c955ae3dd758c3170)
- Requested by @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
