### PR TITLE
docs: add error recovery guidance to SKILL.md [DIS-139]

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -166,6 +166,57 @@ Event types: `sale`, `transfer`, `mint`, `listing`, `offer`, `trait_offer`, `col
 
 Creating new listings and offers requires wallet signatures. Use `opensea-post.sh` with the Seaport order structure - see `references/marketplace-api.md` for full details.
 
+## Error Handling
+
+### Diagnosing failures
+
+When an API call fails, always check the **HTTP status code first** — not the response body. The shell scripts in `scripts/` use `curl`, which exits 0 even on HTTP 4xx/5xx responses. A successful script exit does not mean the API call succeeded. Pipe through `jq` or inspect the HTTP status to detect errors:
+
+```bash
+# Check HTTP status code from a script response
+HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+  -H "x-api-key: $OPENSEA_API_KEY" \
+  "https://api.opensea.io/api/v2/collections/boredapeyachtclub")
+echo "HTTP Status: $HTTP_CODE"
+```
+
+When using the CLI (`@opensea/cli`), check the exit code: `0` = success, `1` = API error, `2` = authentication error. The SDK throws `OpenSeaAPIError` with `statusCode`, `responseBody`, and `path` properties.
+
+### Common error codes
+
+| HTTP Status | Meaning | Recommended Action |
+|---|---|---|
+| 400 | Bad Request | Check parameters against the endpoint docs in `references/rest-api.md` |
+| 401 | Unauthorized | Verify `OPENSEA_API_KEY` is set and valid — test with `opensea collections get boredapeyachtclub` |
+| 404 | Not Found | Verify the collection slug, chain identifier, contract address, or token ID is correct |
+| 429 | Rate Limited | Stop all requests, wait 60 seconds, then retry with exponential backoff |
+| 500 | Server Error | Retry up to 3 times with exponential backoff (wait 2s, 4s, 8s) |
+
+### Rate limit best practices
+
+- **Never run parallel scripts** sharing the same `OPENSEA_API_KEY` — concurrent requests burn through your rate limit and trigger 429 errors
+- **Use exponential backoff** on retries: wait `2^attempt` seconds (2s, 4s, 8s…) with a cap at 60 seconds
+- **Run operations sequentially** — finish one API call before starting the next
+- Rate limits vary by API key tier. Check your limits in the [OpenSea Developer Portal](https://opensea.io/settings/developer)
+
+### Pre-bulk-operation checklist
+
+Before running batch operations (e.g., fetching data for many collections or NFTs), complete this checklist:
+
+1. **Verify your API key works** — run a single test request first:
+   ```bash
+   opensea collections get boredapeyachtclub
+   ```
+2. **Check for already-running processes** — avoid concurrent API usage on the same key:
+   ```bash
+   ps aux | grep opensea
+   ```
+3. **Test with `limit=1`** — confirm the query shape and response format before fetching large datasets:
+   ```bash
+   opensea nfts list-by-collection boredapeyachtclub --limit 1
+   ```
+4. **Run sequentially, not in parallel** — execute one request at a time, waiting for each to complete before starting the next
+
 ## OpenSea CLI (`@opensea/cli`)
 
 The [OpenSea CLI](https://github.com/ProjectOpenSea/opensea-cli) is the recommended way for AI agents to interact with OpenSea. It provides a consistent command-line interface and a programmatic TypeScript/JavaScript SDK.

--- a/SKILL.md
+++ b/SKILL.md
@@ -195,7 +195,7 @@ When using the CLI (`@opensea/cli`), check the exit code: `0` = success, `1` = A
 ### Rate limit best practices
 
 - **Never run parallel scripts** sharing the same `OPENSEA_API_KEY` — concurrent requests burn through your rate limit and trigger 429 errors
-- **Use exponential backoff** on retries: wait `2^attempt` seconds (2s, 4s, 8s…) with a cap at 60 seconds
+- **Use exponential backoff with jitter** on retries: wait `2^attempt` seconds (2s, 4s, 8s…) plus a random delay, capped at 60 seconds
 - **Run operations sequentially** — finish one API call before starting the next
 - Rate limits vary by API key tier. Check your limits in the [OpenSea Developer Portal](https://opensea.io/settings/developer)
 
@@ -209,7 +209,7 @@ Before running batch operations (e.g., fetching data for many collections or NFT
    ```
 2. **Check for already-running processes** — avoid concurrent API usage on the same key:
    ```bash
-   ps aux | grep opensea
+   pgrep -fl opensea
    ```
 3. **Test with `limit=1`** — confirm the query shape and response format before fetching large datasets:
    ```bash


### PR DESCRIPTION
# docs: add error recovery guidance to SKILL.md [DIS-139]

## Summary

Adds a new **Error Handling** section to `SKILL.md` (placed between Buy/Sell workflows and the CLI reference) to give AI agents actionable guidance when OpenSea API calls fail. This addresses [DIS-139](https://linear.app/opensea/issue/DIS-139/opensea-skill-add-error-recovery-guidance-to-skillmd), a subtask of DIS-135 which identified that agents had no error recovery guidance and were getting stuck on API failures.

The new section covers four areas per the ticket spec:
- **Diagnosing failures** — check HTTP status code first, not response body; notes that shell scripts exit 0 on HTTP errors
- **Common error codes table** — 400/401/404/429/500 with specific recommended agent actions
- **Rate limit best practices** — sequential execution, no parallelism per API key, exponential backoff with jitter
- **Pre-bulk-operation checklist** — verify key, check running processes (`pgrep`), test with limit=1, run sequentially

Specific rate limit numbers are intentionally omitted because `rest-api.md` (40 req/min) and `marketplace-api.md` (60 req/min) currently conflict — the guidance instead directs to the Developer Portal.

**Confidence: 🟢 HIGH** — documentation-only change, all four ticket requirements addressed, cross-referenced existing CLI exit codes and SDK error types already in SKILL.md for consistency.

### Updates since last revision
- Added jitter to exponential backoff recommendation to reduce thundering herd
- Changed `ps aux | grep opensea` to `pgrep -fl opensea` to avoid matching the grep process itself

## Review & Testing Checklist for Human

- [ ] Confirm the 429 action ("wait 60 seconds") and 500 retry timing ("2s, 4s, 8s") are reasonable defaults for your API
- [ ] Verify the curl example snippet is a pattern you'd want agents to follow (writes to `/tmp/response.json`, uses `-w "%{http_code}"`)
- [ ] Check placement — the section sits between Buy/Sell workflows and the CLI reference; confirm this is where you want agents to find it

### Notes
- Requested by @ckorhonen
- [Devin Session](https://app.devin.ai/sessions/0d58f762a52b46d687f281d4f7b4e038)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
