### PR TITLE
docs: reconcile rate limit documentation [DIS-142]

### DIFF
--- a/references/marketplace-api.md
+++ b/references/marketplace-api.md
@@ -348,8 +348,11 @@ POST /api/v2/orders/chain/{chain}/protocol/{protocol_address}/hash/{order_hash}/
 
 ## Rate Limits
 
-- Standard: 60 requests/minute
-- With API key: Higher limits (check your dashboard)
+Rate limits apply per-account across all API keys. See `references/rest-api.md` for full details.
+
+**Default limits (Tier 1):** 120 read/min, 60 write/min, 60 fulfillment/min
+
+Fulfillment endpoints (`/api/v2/listings/fulfillment_data`, `/api/v2/offers/fulfillment_data`) use the **fulfillment** rate bucket. Order creation endpoints use the **write** rate bucket. All other GET endpoints use the **read** rate bucket.
 
 ---
 

--- a/references/rest-api.md
+++ b/references/rest-api.md
@@ -101,8 +101,30 @@ For the events endpoint, filter with `event_type`:
 
 ## Rate Limits
 
-- Without API key: 40 requests/minute
-- With API key: Higher limits (varies by tier)
+All v2 endpoints require an API key. OpenSea uses a **token bucket** algorithm: your API key has a bucket of request tokens that refills over a fixed time window. Each request consumes one token. When the bucket is empty, the API returns `429 Too Many Requests`.
+
+All API keys under the same account share a single rate limit bucket. Creating multiple API keys will not increase your overall rate limit.
+
+### Default Rate Limits (Tier 1)
+
+| Operation | Limit |
+|-----------|-------|
+| Read (GET) | 120 requests/minute |
+| Write (POST) | 60 requests/minute |
+| Fulfillment | 60 requests/minute |
+
+Higher tiers are available for select users. You can apply for a rate limit increase via the [OpenSea Developer Portal](https://opensea.io/settings/developer).
+
+### Rate Limit Response Headers
+
+A `429` response includes these headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests allowed in the current time window |
+| `X-RateLimit-Window` | Duration of the time window (e.g., `60s`) |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `Retry-After` | Seconds to wait before retrying |
 
 ## Error Codes
 


### PR DESCRIPTION
# docs: reconcile rate limit documentation [DIS-142]

## Summary

`rest-api.md` and `marketplace-api.md` had conflicting rate limit information that confused agents:
- `rest-api.md` stated "40 requests/minute without API key"
- `marketplace-api.md` stated "60 requests/minute standard"

Neither was accurate per the os2-core codebase. Researched the actual implementation in os2-core (`V39__seed_api_rate_limits.sql`, `DeveloperApiKeyService.kt`, `ApiKeyRateLimitingService.kt`, `ApiKeyInterceptor.kt`) and reconciled both docs:

- **`rest-api.md`** is now the single source of truth for rate limits — documents the token bucket algorithm, default Tier 1 rates (120 read/min, 60 write/min, 60 fulfillment/min), shared per-account bucket, and response headers.
- **`marketplace-api.md`** now references `rest-api.md` and adds context on which marketplace endpoints map to which rate bucket (read/write/fulfillment).

**Confidence: 🟡 MEDIUM** — The rate limit numbers are sourced directly from os2-core database seeds and service code, but I cannot verify whether infrastructure-level overrides (CDN, API gateway) impose different effective limits. The bucket-to-endpoint mapping is inferred from `ApiKeyRateType` annotations but not exhaustively verified against every REST controller.

## Review & Testing Checklist for Human

- [ ] **Verify default Tier 1 rates match production**: The numbers (120 read/min, 60 write/min, 60 fulfillment/min) come from `V39__seed_api_rate_limits.sql` and `ChangeLog00022`. Confirm these haven't been overridden by infrastructure-level rate limiting (CDN, API gateway, etc.) that would make the documented numbers misleading.
- [ ] **Verify "All v2 endpoints require an API key"**: Inferred from `ApiKeyInterceptor` + `@ApiKeyRequired` annotation. Confirm there are no unauthenticated v2 REST endpoints agents might hit.
- [ ] **Verify bucket mapping in marketplace-api.md**: The claim that fulfillment endpoints use the fulfillment bucket and order creation uses the write bucket is based on `ApiKeyRateType` enum usage. Spot-check that the annotations on the actual REST controllers match.
- [ ] **Sanity-check rate limit response headers**: Header names sourced from `ApiKeyInterceptor.kt` — confirm `X-RateLimit-Window` is actually returned (vs. just `X-RateLimit-Limit`).

**Suggested test plan:** Make a few real API calls with a Tier 1 key and inspect the `429` response headers to confirm the documented header names and default limits match what's actually returned.

### Notes
- Requested by: @ckorhonen
- [Devin Session](https://app.devin.ai/sessions/b87909f020f9422189495ba6ad568e82)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
