### PR TITLE
fix(scripts): improve opensea-swap.sh error handling [DIS-140]

### DIFF
--- a/scripts/opensea-swap.sh
+++ b/scripts/opensea-swap.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 # Swap tokens via OpenSea MCP
 # Usage: PRIVATE_KEY=0xYourKey ./opensea-swap.sh <to_token_address> <amount> <wallet_address> [chain] [from_token]
 #
@@ -6,7 +8,7 @@
 #   PRIVATE_KEY=0xYourKey ./opensea-swap.sh 0xb695559b26bb2c9703ef1935c37aeae9526bab07 0.02 0xYourWallet base
 #   PRIVATE_KEY=0xYourKey ./opensea-swap.sh 0xToToken 100 0xYourWallet base 0xFromToken
 #
-# Requires: OPENSEA_API_KEY env var, PRIVATE_KEY env var, mcporter, node with viem
+# Requires: OPENSEA_API_KEY env var, PRIVATE_KEY env var, mcporter, node with viem, jq
 
 TO_TOKEN="${1:?Usage: PRIVATE_KEY=0x... $0 <to_token_address> <amount> <wallet_address> [chain] [from_token]}"
 AMOUNT="${2:?Amount required}"
@@ -15,29 +17,40 @@ CHAIN="${4:-base}"
 FROM_TOKEN="${5:-0x0000000000000000000000000000000000000000}"
 
 if [ -z "$PRIVATE_KEY" ]; then
-  echo "❌ PRIVATE_KEY environment variable is required"
+  echo "❌ PRIVATE_KEY environment variable is required" >&2
   exit 1
 fi
+
+TMPFILE=$(mktemp /tmp/opensea_swap_quote.XXXXXX.json)
+trap 'rm -f "$TMPFILE"' EXIT
 
 echo "🔄 Getting swap quote: ${AMOUNT} tokens → token on ${CHAIN}..."
 
 # Get swap quote via mcporter
-QUOTE=$(mcporter call opensea.get_token_swap_quote --args "{
+if ! QUOTE=$(mcporter call opensea.get_token_swap_quote --args "{
   \"fromContractAddress\": \"${FROM_TOKEN}\",
   \"fromChain\": \"${CHAIN}\",
   \"toContractAddress\": \"${TO_TOKEN}\",
   \"toChain\": \"${CHAIN}\",
   \"fromQuantity\": \"${AMOUNT}\",
   \"address\": \"${WALLET}\"
-}" --output raw 2>&1)
-
-if echo "$QUOTE" | grep -q "error"; then
-  echo "❌ Failed to get quote: $QUOTE"
+}" --output raw 2>&1); then
+  echo "❌ Failed to get quote: $QUOTE" >&2
   exit 1
 fi
 
-# Save quote for parsing
-echo "$QUOTE" > /tmp/opensea_swap_quote.json
+if ! echo "$QUOTE" | jq empty 2>/dev/null; then
+  echo "❌ Invalid response (not JSON): $QUOTE" >&2
+  exit 1
+fi
+
+if echo "$QUOTE" | jq -e '.error // .isError // empty' >/dev/null 2>&1; then
+  echo "❌ Failed to get quote: $QUOTE" >&2
+  exit 1
+fi
+
+# Save quote for parsing by node
+echo "$QUOTE" > "$TMPFILE"
 
 # Execute with node
 node --input-type=module -e "
@@ -54,7 +67,7 @@ const wallet = createWalletClient({ account, chain, transport: http() });
 const pub = createPublicClient({ chain, transport: http() });
 
 // Parse the mcporter output (wrapped in content structure)
-const raw = readFileSync('/tmp/opensea_swap_quote.json', 'utf8');
+const raw = readFileSync('${TMPFILE}', 'utf8');
 let quote;
 try {
   const wrapper = JSON.parse(raw);

--- a/scripts/opensea-swap.sh
+++ b/scripts/opensea-swap.sh
@@ -16,7 +16,7 @@ WALLET="${3:?Wallet address required}"
 CHAIN="${4:-base}"
 FROM_TOKEN="${5:-0x0000000000000000000000000000000000000000}"
 
-if [ -z "$PRIVATE_KEY" ]; then
+if [ -z "${PRIVATE_KEY:-}" ]; then
   echo "❌ PRIVATE_KEY environment variable is required" >&2
   exit 1
 fi


### PR DESCRIPTION
# fix(scripts): improve opensea-swap.sh error handling [DIS-140]

## Summary

Builds on the robustness changes from DIS-135 (merged in #13) with three targeted improvements to error handling in `opensea-swap.sh`:

| Change | Before (on `main`) | After |
|---|---|---|
| mcporter failure handling | `QUOTE=$(...) \|\| { ... }` | `if ! QUOTE=$(...); then ... fi` — idiomatic under `set -e` |
| JSON validation | none — non-JSON responses passed silently to jq error check | `jq empty` gate rejects non-JSON with a clear message |
| Error field check | `.error // empty` | `.error // .isError // empty` — catches both error shapes |

Also adds `jq` to the requirements comment (line 11) since it's now a runtime dependency.

## Review & Testing Checklist for Human

- [ ] **`.isError` field (line 46):** Verify `mcporter` actually returns `.isError` in some error cases, or remove it if `.error` is sufficient. If neither field is used, the check is a no-op (safe but ineffective).
- [ ] **`if !` vs `|| {` pattern (line 29):** Confirm the `if ! QUOTE=$(...)` form captures both stdout and the exit code correctly in your shell version. The previous `|| {` form also worked; this is a style change with minor semantic difference.
- [ ] **End-to-end test:** Run a swap quote (or intentionally bad request) to verify the new `jq empty` check catches malformed responses and the error messages are helpful.

### Notes
- The diff is small (net +9 lines) since DIS-135 already landed the major fixes (shebang, strict mode, mktemp/trap, stderr routing).
- Confidence: 🟢 HIGH — incremental improvements to patterns already established on `main`.
- Requested by: @ckorhonen
- [Devin Session](https://app.devin.ai/sessions/d3e3a836ff714b1ca2f2f5c96aba402b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
