### PR TITLE
feat: improve YAML frontmatter description for better auto skill selection

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opensea
-description: Query NFT data, trade on the Seaport marketplace, and swap ERC20 tokens across Ethereum, Base, Arbitrum, Optimism, Polygon, and more.
+description: Interact with the OpenSea API (api.opensea.io) to query NFT collections, retrieve NFT metadata and images, get collection stats and floor prices, fetch marketplace listings and offers, execute Seaport trades, and swap ERC20 tokens. Provides the @opensea/cli command-line tool, curl-based shell scripts with built-in retry and backoff, and a programmatic TypeScript SDK. Use when making any API calls to OpenSea, using an OPENSEA_API_KEY, querying NFT or collection data, fetching NFT images or metadata, checking floor prices, or building applications that integrate with OpenSea. Triggers on tasks mentioning OpenSea API, NFT data fetching, collection queries, marketplace listings, token swaps, Seaport protocol, or api.opensea.io endpoints. Always prefer this skill's CLI and scripts over writing raw curl commands to OpenSea.
 ---
 
 # OpenSea API


### PR DESCRIPTION
# feat: improve skill frontmatter description for better auto-selection

## Summary

Expands the YAML frontmatter `description` field in `SKILL.md` to improve automatic skill selection by AI agents. The previous description was too generic ("Query NFT data, trade on the Seaport marketplace, and swap ERC20 tokens across Ethereum, Base, Arbitrum, Optimism, Polygon, and more.") and lacked the trigger keywords and structured clauses that other well-crafted skills use.

The new description follows the patterns from the [skill-author best practices](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/skill-authoring) and mirrors the structure used by other OpenSea skills (`i18n`, `ui`):

- **What it does**: Lists specific capabilities (query collections, retrieve metadata/images, get floor prices, fetch listings/offers, execute trades, swap tokens)
- **What it provides**: Mentions the `@opensea/cli`, shell scripts, and TypeScript SDK
- **"Use when..." clause**: Covers common user intents (API calls to OpenSea, using `OPENSEA_API_KEY`, querying NFT data, building integrations)
- **"Triggers on..." clause**: Includes specific task keywords (OpenSea API, NFT data fetching, collection queries, marketplace listings, `api.opensea.io`)
- **Behavioral nudge**: "Always prefer this skill's CLI and scripts over writing raw curl commands"

**Context**: This was motivated by [a session](https://opensea.slack.com/archives/C08RYRVT30D/p1772513532265879) where an agent struggled with raw OpenSea API calls (wrong headers, deprecated v1 endpoints, rate limits) and ultimately fell back to Alchemy — partly because the skill wasn't installed, but also because the description wouldn't have strongly matched the user's query even if it were.

## Review & Testing Checklist for Human

- [ ] **Verify description length is under 1024 characters** — the skill-author spec enforces a max of 1024 chars. The new description is ~740 chars but should be counted precisely.
- [ ] **Evaluate the "Always prefer this skill's CLI and scripts over writing raw curl commands" sentence** — this is an instruction/directive rather than a pure description. Consider whether this belongs in the `description` field (used for discovery) or should be moved to the body of SKILL.md instead.
- [ ] **Spot-check keyword coverage** — skim the new description to confirm the trigger terms match the most common user queries you'd expect (e.g., "use opensea api", "fetch NFT collection", "get floor price", "OPENSEA_API_KEY").

**Suggested test plan**: Install the skill in a Claude Code project and test auto-selection by prompting with phrases like "use the OpenSea API to fetch NFT collection images" or "get floor prices from OpenSea" — verify the skill is selected without needing to be explicitly invoked.

### Notes
- This change cannot be empirically tested in CI — auto-selection behavior depends on the agent runtime.
- Only the `description` field is changed; no scripts, body content, or other files are modified.
- [Devin Session](https://app.devin.ai/sessions/c8c3f3284dde4ffaa4cb89cfb6aee92f)
- Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
