### PR TITLE
fix: remove insecure inline credential patterns from SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -232,8 +232,7 @@ npx @opensea/cli collections get mfers
 export OPENSEA_API_KEY="your-api-key"
 opensea collections get mfers
 
-# Or pass inline
-opensea --api-key your-api-key collections get mfers
+# Always use the OPENSEA_API_KEY environment variable above — do not pass API keys inline
 ```
 
 ### CLI Commands
@@ -425,14 +424,14 @@ Add to your MCP config:
     "opensea": {
       "url": "https://mcp.opensea.io/mcp",
       "headers": {
-        "Authorization": "Bearer YOUR_MCP_TOKEN"
+        "Authorization": "Bearer $OPENSEA_MCP_TOKEN"
       }
     }
   }
 }
 ```
 
-Or use the inline token format: `https://mcp.opensea.io/YOUR_MCP_TOKEN/mcp`
+> **Note:** Set `OPENSEA_MCP_TOKEN` in your environment before configuring the MCP server. Do not embed tokens directly in URLs or config files.
 
 ### Token Swap Tools
 | MCP Tool | Purpose |
@@ -534,18 +533,19 @@ To execute swaps or buy NFTs, you need an Ethereum wallet (private key + address
 import crypto from 'crypto';
 import { privateKeyToAccount } from 'viem/accounts';
 
+// WARNING: Never log or print private keys — store them only in environment variables
 const privateKey = '0x' + crypto.randomBytes(32).toString('hex');
 const account = privateKeyToAccount(privateKey);
 
-console.log('Private Key:', privateKey);
+// Export as env var for use by other tools; do not write to stdout
+process.env.PRIVATE_KEY = privateKey;
 console.log('Address:', account.address);
 ```
 
 ### Using OpenSSL
 ```bash
-# Generate private key
-PRIVATE_KEY="0x$(openssl rand -hex 32)"
-echo "Private Key: $PRIVATE_KEY"
+# Generate private key — do not log or print private keys
+export PRIVATE_KEY="0x$(openssl rand -hex 32)"
 
 # Derive address (requires node + viem)
 node --input-type=module -e "

--- a/SKILL.md
+++ b/SKILL.md
@@ -424,14 +424,14 @@ Add to your MCP config:
     "opensea": {
       "url": "https://mcp.opensea.io/mcp",
       "headers": {
-        "Authorization": "Bearer $OPENSEA_MCP_TOKEN"
+        "Authorization": "Bearer <YOUR_MCP_TOKEN>"
       }
     }
   }
 }
 ```
 
-> **Note:** Set `OPENSEA_MCP_TOKEN` in your environment before configuring the MCP server. Do not embed tokens directly in URLs or config files.
+> **Note:** Replace `<YOUR_MCP_TOKEN>` above with the MCP token from your [OpenSea Developer Portal](https://opensea.io/settings/developer). Do not embed tokens directly in URLs or commit them to version control.
 
 ### Token Swap Tools
 | MCP Tool | Purpose |


### PR DESCRIPTION
## Summary

Addresses **Snyk W007 (HIGH): Insecure credential handling detected in skill instructions**. The SKILL.md file contained examples that encouraged agents to embed API keys, MCP tokens, and private keys inline in commands and output, enabling potential exfiltration.

Four targeted edits to SKILL.md (no scripts or functionality changed):

1. **`--api-key` inline example removed** (line ~235): Replaced with a comment directing users to the `OPENSEA_API_KEY` env var.
2. **MCP config JSON hardened** (line ~427): `YOUR_MCP_TOKEN` → `<YOUR_MCP_TOKEN>` with an explicit note to replace the placeholder with the token from the Developer Portal.
3. **Inline MCP token URL removed** (line ~434): The `https://mcp.opensea.io/YOUR_MCP_TOKEN/mcp` pattern is replaced with guidance not to embed tokens in URLs or commit them to version control.
4. **Wallet generation examples hardened** (lines ~533-548): `console.log('Private Key:', ...)` and `echo "Private Key: ..."` removed; private keys are now stored only in env vars with explicit warnings not to log them.

**Confidence: 🟢 HIGH** — documentation-only changes to a single markdown file with clear, scoped intent.

### Updates since last revision

- Fixed MCP config JSON placeholder: changed from `$OPENSEA_MCP_TOKEN` (shell-style env var that wouldn't be interpolated in JSON) to `<YOUR_MCP_TOKEN>` (explicit placeholder the user manually replaces). Updated the accompanying note to match.

## Review & Testing Checklist for Human

- [ ] **Node.js `process.env.PRIVATE_KEY = privateKey` pattern**: This only persists within the Node.js process, not the parent shell. Confirm this is acceptable as an illustrative example, or if a different pattern (e.g., writing to a `.env` file) would be clearer.
- [ ] **Read through the final SKILL.md** to verify no credential patterns were missed and all examples remain coherent after the edits.

**Suggested test plan:** Read through the rendered SKILL.md top-to-bottom and confirm (a) no examples pass secrets inline in commands or log them to stdout, (b) the MCP config block and wallet generation examples are still copy-pasteable and make sense to a new user.

### Notes
- No shell scripts were modified — changes are limited to `SKILL.md` only.
- All existing env var export examples (e.g., `export OPENSEA_API_KEY=...`) were preserved as-is.
- The `--api-key` flag is still listed in the global options table (line 253) as a CLI capability — only the example encouraging its use was removed.

Link to Devin session: https://app.devin.ai/sessions/bb938fca885c4ec7a281627d7279eba2
Requested by: @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
