### PR TITLE
fix: harden opensea-swap.sh against compromised quote responses

### DIFF
--- a/scripts/opensea-swap.sh
+++ b/scripts/opensea-swap.sh
@@ -17,7 +17,7 @@ CHAIN="${4:-base}"
 FROM_TOKEN="${5:-0x0000000000000000000000000000000000000000}"
 
 ALLOWED_CHAINS="base ethereum mainnet polygon matic arbitrum optimism"
-if ! echo " $ALLOWED_CHAINS " | grep -q " $CHAIN "; then
+if ! echo " $ALLOWED_CHAINS " | grep -qF " $CHAIN "; then
   echo "Invalid chain '${CHAIN}'. Allowed: ${ALLOWED_CHAINS}" >&2
   exit 1
 fi
@@ -95,8 +95,8 @@ if (!ethAddrRegex.test(txData.to)) {
   process.exit(1);
 }
 
-const valueStr = String(txData.value);
-if (!/^\d+$/.test(valueStr)) {
+const valueBigInt = (() => { try { return BigInt(txData.value); } catch { return null; } })();
+if (valueBigInt === null || valueBigInt < 0n) {
   console.error('ERROR: Invalid transaction value (not a non-negative integer):', txData.value);
   process.exit(1);
 }

--- a/scripts/opensea-swap.sh
+++ b/scripts/opensea-swap.sh
@@ -16,12 +16,19 @@ WALLET="${3:?Wallet address required}"
 CHAIN="${4:-base}"
 FROM_TOKEN="${5:-0x0000000000000000000000000000000000000000}"
 
+ALLOWED_CHAINS="base ethereum mainnet polygon matic arbitrum optimism"
+if ! echo " $ALLOWED_CHAINS " | grep -q " $CHAIN "; then
+  echo "Invalid chain '${CHAIN}'. Allowed: ${ALLOWED_CHAINS}" >&2
+  exit 1
+fi
+
 if [ -z "${PRIVATE_KEY:-}" ]; then
   echo "PRIVATE_KEY environment variable is required" >&2
   exit 1
 fi
 
 tmp_quote=$(mktemp)
+chmod 600 "$tmp_quote"
 trap 'rm -f "$tmp_quote"' EXIT
 
 echo "Getting swap quote: ${AMOUNT} tokens on ${CHAIN}..." >&2
@@ -72,7 +79,28 @@ try {
   quote = JSON.parse(raw);
 }
 
+if (!quote.swap?.actions?.[0]?.transactionSubmissionData) {
+  console.error('ERROR: Quote response missing swap.actions[0].transactionSubmissionData');
+  process.exit(1);
+}
 const txData = quote.swap.actions[0].transactionSubmissionData;
+if (!txData.to || !txData.data || txData.value === undefined) {
+  console.error('ERROR: transactionSubmissionData missing required fields (to, data, value)');
+  process.exit(1);
+}
+
+const ethAddrRegex = /^0x[0-9a-fA-F]{40}$/;
+if (!ethAddrRegex.test(txData.to)) {
+  console.error('ERROR: Invalid destination address:', txData.to);
+  process.exit(1);
+}
+
+const valueStr = String(txData.value);
+if (!/^\d+$/.test(valueStr)) {
+  console.error('ERROR: Invalid transaction value (not a non-negative integer):', txData.value);
+  process.exit(1);
+}
+
 const toSymbol = quote.swapQuote.swapRoutes[0].toAsset.symbol;
 
 console.error('Quote received — To:', txData.to, 'Value:', txData.value, 'wei', 'Token:', toSymbol);


### PR DESCRIPTION
# fix: harden opensea-swap.sh against compromised quote responses

## Summary

Addresses the Socket security audit finding that `scripts/opensea-swap.sh` trusts external `mcporter` output and signs/broadcasts whatever transaction is returned without validation. If `mcporter`, the quote provider, or the temp file is compromised, an attacker could cause loss of funds.

This PR adds five defensive checks **without changing the swap flow, CLI interface, or capabilities**:

1. **Chain allowlist** — `CHAIN` is validated against `base ethereum mainnet polygon matic arbitrum optimism` using fixed-string matching (`grep -qF`) before it's shell-interpolated into the inline Node.js block (prevents JS injection via crafted chain name)
2. **Temp file permissions** — `chmod 600` after `mktemp` so only the owner can read/write the quote file
3. **Quote structure validation** — Verifies `quote.swap.actions[0].transactionSubmissionData` exists and contains `to`, `data`, and `value`
4. **Destination address validation** — Regex check that `txData.to` matches `^0x[0-9a-fA-F]{40}$`
5. **Transaction value validation** — Uses `BigInt(txData.value)` to confirm the value is a valid non-negative integer; handles both string and numeric JSON values (including scientific notation for large wei amounts)

**Confidence: 🟡 MEDIUM-HIGH** — The validation logic is straightforward, but there are no automated tests for this script and changes were not exercised against a live swap.

### Updates since last revision

- Fixed chain validation to use `grep -qF` (fixed-string) instead of `grep -q` (regex), preventing patterns like `b.se` from matching `base`.
- Replaced `/^\d+$/` regex for value validation with `BigInt()`-based check, which correctly handles large numeric JSON values that JavaScript would render in scientific notation (e.g. `1e+21`).

## Review & Testing Checklist for Human

- [ ] **Verify the chain allowlist is complete.** Compare `ALLOWED_CHAINS` against the chains supported by the viem imports on line 63 and the `chains` map on line 66-67. If new chains are added later, this allowlist must be updated too.
- [ ] **Note that `${CHAIN}` is still shell-interpolated into the Node.js heredoc** on line 67 (`chains['${CHAIN}']`). The allowlist makes this safe, but the pattern is inherently fragile — reviewer should assess whether this is acceptable long-term.
- [ ] **Test a legitimate swap end-to-end** (e.g. on Base testnet) to confirm the validations don't reject valid quote responses.

### Notes
- The `$tmp_quote` file path is also shell-interpolated into the Node.js block (line 73). This is unchanged and mitigated by `mktemp` producing predictable safe paths, but worth being aware of.
- No existing tests or CI for shell scripts in this repo, so manual verification is the only option.
- [Devin Session](https://app.devin.ai/sessions/9355bd4d08cf48ceb0f5483f2855e398) · Requested by @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
