### PR TITLE
feat: add input validation to shell scripts

### DIFF
--- a/scripts/opensea-fulfill-listing.sh
+++ b/scripts/opensea-fulfill-listing.sh
@@ -11,6 +11,23 @@ fi
 chain="$1"
 order_hash="$2"
 fulfiller="$3"
+
+valid_chains="^(ethereum|matic|arbitrum|optimism|base|avalanche|klaytn|zora|blast|sepolia)$"
+if [[ ! "$chain" =~ $valid_chains ]]; then
+  echo "opensea-fulfill-listing.sh: invalid chain '$chain'" >&2
+  exit 1
+fi
+
+if [[ ! "$order_hash" =~ ^0x[0-9a-fA-F]+$ ]]; then
+  echo "opensea-fulfill-listing.sh: order_hash must be hex (0x...)" >&2
+  exit 1
+fi
+
+if [[ ! "$fulfiller" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "opensea-fulfill-listing.sh: fulfiller must be a valid Ethereum address (0x + 40 hex chars)" >&2
+  exit 1
+fi
+
 protocol="0x0000000000000068f116a894984e2db1123eb395"
 
 body=$(cat <<EOF

--- a/scripts/opensea-fulfill-offer.sh
+++ b/scripts/opensea-fulfill-offer.sh
@@ -13,6 +13,33 @@ order_hash="$2"
 fulfiller="$3"
 contract="$4"
 token_id="$5"
+
+valid_chains="^(ethereum|matic|arbitrum|optimism|base|avalanche|klaytn|zora|blast|sepolia)$"
+if [[ ! "$chain" =~ $valid_chains ]]; then
+  echo "opensea-fulfill-offer.sh: invalid chain '$chain'" >&2
+  exit 1
+fi
+
+if [[ ! "$order_hash" =~ ^0x[0-9a-fA-F]+$ ]]; then
+  echo "opensea-fulfill-offer.sh: order_hash must be hex (0x...)" >&2
+  exit 1
+fi
+
+if [[ ! "$fulfiller" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "opensea-fulfill-offer.sh: fulfiller must be a valid Ethereum address (0x + 40 hex chars)" >&2
+  exit 1
+fi
+
+if [[ ! "$contract" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "opensea-fulfill-offer.sh: contract must be a valid Ethereum address (0x + 40 hex chars)" >&2
+  exit 1
+fi
+
+if [[ ! "$token_id" =~ ^[0-9]+$ ]]; then
+  echo "opensea-fulfill-offer.sh: token_id must be a non-negative integer" >&2
+  exit 1
+fi
+
 protocol="0x0000000000000068f116a894984e2db1123eb395"
 
 body=$(cat <<EOF

--- a/scripts/opensea-get.sh
+++ b/scripts/opensea-get.sh
@@ -9,6 +9,11 @@ fi
 
 path="$1"
 query="${2-}"
+
+if [[ "$path" != /* ]]; then
+  echo "opensea-get.sh: path must start with /" >&2
+  exit 1
+fi
 base="${OPENSEA_BASE_URL:-https://api.opensea.io}"
 key="${OPENSEA_API_KEY:-}"
 

--- a/scripts/opensea-post.sh
+++ b/scripts/opensea-post.sh
@@ -9,6 +9,11 @@ fi
 
 path="$1"
 body="$2"
+
+if [[ "$path" != /* ]]; then
+  echo "opensea-post.sh: path must start with /" >&2
+  exit 1
+fi
 base="${OPENSEA_BASE_URL:-https://api.opensea.io}"
 key="${OPENSEA_API_KEY:-}"
 

--- a/scripts/opensea-stream-collection.sh
+++ b/scripts/opensea-stream-collection.sh
@@ -7,6 +7,12 @@ if [ "$#" -lt 1 ]; then
 fi
 
 slug="$1"
+
+if [[ ! "$slug" =~ ^[a-zA-Z0-9*-]+$ ]]; then
+  echo "opensea-stream-collection.sh: slug must contain only alphanumeric characters, hyphens, and asterisk" >&2
+  exit 1
+fi
+
 key="${OPENSEA_API_KEY:-}"
 
 if [ -z "$key" ]; then


### PR DESCRIPTION
# feat: add input validation to shell scripts

## Summary

Addresses the Agent Trust Hub audit finding that shell scripts in `scripts/` execute system commands with user-provided arguments that are not validated. Several scripts construct JSON bodies via heredocs or interpolate values directly into WebSocket messages without any input sanitization.

This PR adds inline bash regex validation to all five scripts that accept user input, rejecting obviously malicious or malformed values before they reach `curl`, heredoc interpolation, or WebSocket messages:

| Script | Validations added |
|---|---|
| `opensea-get.sh` | `$path` must start with `/` |
| `opensea-post.sh` | `$path` must start with `/` |
| `opensea-fulfill-listing.sh` | `$chain` against allowlist, `$order_hash` hex format, `$fulfiller` Ethereum address format |
| `opensea-fulfill-offer.sh` | Same as listing + `$contract` Ethereum address format, `$token_id` non-negative integer |
| `opensea-stream-collection.sh` | `$slug` alphanumeric + hyphens + asterisk only (prevents JSON injection) |

No behavioral changes — scripts that receive valid input behave identically to before.

**Confidence: 🟢 HIGH** — straightforward regex guards with no logic changes. Syntax-checked all scripts with `bash -n`. No test suite exists in this repo to run.

## Review & Testing Checklist for Human

- [ ] Verify the **chain allowlist** (`ethereum|matic|arbitrum|optimism|base|avalanche|klaytn|zora|blast|sepolia`) is complete — if OpenSea supports additional chains, they'll need to be added here and in `opensea-fulfill-offer.sh`
- [ ] Confirm `order_hash` regex (`^0x[0-9a-fA-F]+$`) is intentionally length-flexible — real order hashes are 66 chars but the regex accepts any length. Tighten to `{64}` if desired
- [ ] Spot-check that the validation in `opensea-fulfill-offer.sh` duplicates the listing validations correctly (chain/order_hash/fulfiller patterns are inlined in both files rather than shared)
- [ ] Manually test one script with valid and invalid args to confirm the guards fire correctly, e.g.:
  ```bash
  # Should fail:
  ./scripts/opensea-get.sh "evil-path"
  ./scripts/opensea-fulfill-listing.sh "badchain" "0xabc" "0x1234"
  ./scripts/opensea-stream-collection.sh '"; drop table'
  
  # Should pass validation (will fail at API call without key, but that's expected):
  OPENSEA_API_KEY=test ./scripts/opensea-get.sh "/api/v2/collections/test"
  ```

### Notes
- No test suite exists in this repo, so validation is limited to syntax checking (`bash -n`) and manual review
- Validation is inlined per the task guidance ("shared helper or inline — whichever is simpler"); for 5 scripts this felt appropriate
- [Devin Session](https://app.devin.ai/sessions/448870806162412181c85377e7a8cb21)
- Requested by @ckorhonen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
