### PR TITLE
fix: use chain-specific block explorer URL for swap transactions

### DIFF
--- a/scripts/opensea-swap.sh
+++ b/scripts/opensea-swap.sh
@@ -112,7 +112,8 @@ const hash = await wallet.sendTransaction({
   value: BigInt(txData.value)
 });
 
-console.error('TX: https://basescan.org/tx/' + hash);
+const explorerUrl = chain.blockExplorers?.default?.url || 'https://basescan.org';
+console.error('TX: ' + explorerUrl + '/tx/' + hash);
 console.error('Waiting for confirmation...');
 
 const receipt = await pub.waitForTransactionReceipt({ hash });


### PR DESCRIPTION
The transaction URL was hardcoded to basescan.org, showing wrong explorer links for swaps on Ethereum, Polygon, Arbitrum, and Optimism. Now uses the viem chain object's blockExplorers to get the correct URL.

The problem: The script supports 5+ chains (base, ethereum, polygon, arbitrum, optimism) via the CHAIN parameter (line 16-23), and the viem chain selection correctly handles all of them (line 66-67). But the transaction URL is hardcoded to basescan.org. When a user swaps on Ethereum, Arbitrum, Polygon, or Optimism, they get a wrong/broken explorer link that won't resolve their transaction.

Fix: Map the chain to the correct explorer URL, e.g. using chain.blockExplorers.default.url from the viem chain object which already has this data.