### PR TITLE
docs: replace /skill install with npx skills add

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,8 @@ Get both credentials at [opensea.io/settings/developer](https://opensea.io/setti
 
 ## Installing the Skill
 
-### Using npx
-
 ```bash
 npx skills add ProjectOpenSea/opensea-skill
-```
-
-### Using Claude Code
-
-```bash
-/skill install ProjectOpenSea/opensea-skill
 ```
 
 ### Manual Installation


### PR DESCRIPTION
## Summary

Removes the deprecated `/skill install ProjectOpenSea/opensea-skill` (Claude Code) installation method from the README. The "Using npx" and "Using Claude Code" subsections are collapsed into a single `npx skills add` command, which is the preferred installation method across all supported AI tools.

## Review & Testing Checklist for Human

- [ ] Confirm `npx skills add` works correctly for Claude Code users (since the Claude Code-specific `/skill install` path was removed)

### Notes

- Companion PR in `opensea-docs` was already merged: https://github.com/ProjectOpenSea/opensea-docs/pull/22
- Requested by: @ckorhonen
- [Devin Session](https://app.devin.ai/sessions/49d28c63716e4f81963faa01ce58cfbb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
