### PR TITLE
docs: add instant API key as primary auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ This is an [Agent Skill](https://skills.sh/docs) for AI coding assistants. Once 
 - `curl` — for REST shell scripts
 - `jq` (recommended) — for parsing JSON responses
 
-Get your API key at [opensea.io/settings/developer](https://opensea.io/settings/developer). The same key works for the REST API, CLI, and MCP server.
+Get an API key instantly (no signup needed):
+```bash
+curl -s -X POST https://api.opensea.io/api/v2/auth/keys | jq -r '.api_key'
+```
+
+Or get a full key at [opensea.io/settings/developer](https://opensea.io/settings/developer) for higher rate limits. The same key works for the REST API, CLI, and MCP server.
 
 For write operations (swaps, Seaport fulfillment), you'll need a wallet that can sign transactions. Use whatever fits your security model — Privy, Fireblocks, a backend signing proxy, etc.
 
@@ -94,12 +99,14 @@ An official MCP server provides direct LLM integration for token swaps and NFT o
     "opensea": {
       "url": "https://mcp.opensea.io/mcp",
       "headers": {
-        "X-API-KEY": "OPENSEA_API_KEY"
+        "X-API-KEY": "YOUR_API_KEY"
       }
     }
   }
 }
 ```
+
+Get an instant API key with `curl -s -X POST https://api.opensea.io/api/v2/auth/keys | jq -r '.api_key'` or from [opensea.io/settings/developer](https://opensea.io/settings/developer).
 
 See [`SKILL.md`](SKILL.md) for the full list of available MCP tools.
 
@@ -130,4 +137,5 @@ This skill supports all chains available on OpenSea, including `ethereum`, `sola
 - [OpenSea CLI](https://github.com/ProjectOpenSea/opensea-cli) — CLI and SDK for OpenSea API
 - [OpenSea Developer Docs](https://docs.opensea.io/)
 - [OpenSea Developer Portal](https://opensea.io/settings/developer)
+- [Instant API Key](https://docs.opensea.io/reference/api-keys#instant-api-key-for-agents) — get a free-tier key with a single API call
 - [Agent Skills Directory](https://skills.sh/docs)

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ env:
   OPENSEA_API_KEY:
     description: API key for all OpenSea services — REST API, CLI, SDK, and MCP server
     required: true
-    obtain: https://opensea.io/settings/developer
+    obtain: curl -s -X POST https://api.opensea.io/api/v2/auth/keys | jq -r '.api_key'
   PRIVY_APP_ID:
     description: Privy application ID for wallet signing (default provider)
     required: false
@@ -29,12 +29,16 @@ Query NFT data, trade on the Seaport marketplace, and swap ERC20 tokens across E
 
 ## Quick start
 
-1. Set `OPENSEA_API_KEY` in your environment
+1. Get an API key — instantly via API (no signup needed) or from the [developer portal](https://opensea.io/settings/developer)
 2. **Preferred:** Use the `opensea` CLI (`@opensea/cli`) for all queries and operations
 3. Alternatively, use the shell scripts in `scripts/` or the MCP server
 
 ```bash
-export OPENSEA_API_KEY="your-api-key"
+# Get an instant free-tier API key (no signup needed)
+export OPENSEA_API_KEY=$(curl -s -X POST https://api.opensea.io/api/v2/auth/keys | jq -r '.api_key')
+
+# Or set an existing key
+# export OPENSEA_API_KEY="your-api-key"
 
 # Install the CLI globally (or use npx)
 npm install -g @opensea/cli

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ env:
   OPENSEA_API_KEY:
     description: API key for all OpenSea services — REST API, CLI, SDK, and MCP server
     required: true
-    obtain: curl -s -X POST https://api.opensea.io/api/v2/auth/keys | jq -r '.api_key'
+    obtain: https://docs.opensea.io/reference/api-keys#instant-api-key-for-agents
   PRIVY_APP_ID:
     description: Privy application ID for wallet signing (default provider)
     required: false


### PR DESCRIPTION
## Thanks for opening a PR!

We really appreciate you taking the time to contribute. It means a lot to the OpenSea team and the broader developer community.

### A quick note about how this repo works

This repository is a **read-only mirror** of a package maintained in an internal monorepo. Because of that, pull requests cannot be merged directly here.

**But don't worry -- your contribution won't be lost!** Here's what happens next:

1. Our team reviews every PR that comes in.
2. If the change looks good, we'll recreate it internally in our monorepo.
3. The fix will be synced back to this public repo on the next release.

We'll keep you posted on the PR as things progress.

### Is this a bug report?

If you're reporting a bug rather than submitting a code fix, opening an **issue** is usually the fastest path to a resolution. Bug report issues help us triage and prioritize effectively.

Thanks again for helping make OpenSea better for everyone!

---

## Summary

Updates SKILL.md and README.md to surface the new instant API key endpoint (`POST /api/v2/auth/keys`) as the primary way for agents to get started — no portal signup needed. The endpoint ships in [os2-core#37950](https://github.com/ProjectOpenSea/os2-core/pull/37950) behind a feature flag.

**Changes:**
- **SKILL.md**: `obtain` field now points to the instant API key docs page; quick start demonstrates instant key creation first with existing-key fallback commented below
- **README.md**: Prerequisites, MCP config, and Learn More sections updated with instant key references; also fixes the MCP JSON example placeholder (`OPENSEA_API_KEY` → `YOUR_API_KEY`)

### Updates since last revision
- **`obtain` field fix**: Changed from a shell command back to a URL (`https://docs.opensea.io/reference/api-keys#instant-api-key-for-agents`) to preserve compatibility with skills.sh tooling that expects clickable links. The curl command is still shown in the Quick Start body text.

## Review Checklist

- [x] **`obtain` field format**: Now uses a docs URL (not a shell command), so skills.sh tooling that expects a link will work correctly.
- [ ] **`jq` dependency**: Quick start and README one-liners use `jq -r '.api_key'` but jq is listed as "recommended", not required. Users without jq will get a broken `OPENSEA_API_KEY`. Consider whether to require jq or add a fallback note.
- [ ] **Endpoint availability**: The `POST /api/v2/auth/keys` endpoint doesn't exist yet — it ships with os2-core#37950 behind the `instant_api_keys` Unleash flag. These docs should be coordinated with that rollout.
- [ ] **Docs link in `obtain`**: Points to `docs.opensea.io/reference/api-keys#instant-api-key-for-agents` which ships in [opensea-docs#43](https://github.com/ProjectOpenSea/opensea-docs/pull/43). Both PRs need to land together.

Link to Devin session: https://app.devin.ai/sessions/be77d516167f44ebb9dbb92056001cd0
Requested by: @ryanio
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/projectopensea/opensea-skill/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
