### PR TITLE
fix(security): prevent API key from leaking in stream script output [DIS-86]

### DIFF
--- a/scripts/opensea-stream-collection.sh
+++ b/scripts/opensea-stream-collection.sh
@@ -21,10 +21,12 @@ if [ -z "$key" ]; then
 fi
 
 url="wss://stream.openseabeta.com/socket/websocket?token=${key}"
+masked_url="wss://stream.openseabeta.com/socket/websocket?token=***"
 join="{\"topic\":\"collection:${slug}\",\"event\":\"phx_join\",\"payload\":{},\"ref\":1}"
 heartbeat="{\"topic\":\"phoenix\",\"event\":\"heartbeat\",\"payload\":{},\"ref\":0}"
 
 if command -v websocat >/dev/null 2>&1; then
+  echo "Connecting to Stream API (collection: ${slug})..." >&2
   {
     printf '%s\n' "$join"
     while sleep 30; do
@@ -35,9 +37,9 @@ if command -v websocat >/dev/null 2>&1; then
 fi
 
 if command -v wscat >/dev/null 2>&1; then
-  cat <<INFO
+  cat >&2 <<INFO
 wscat is installed, but it does not auto-send join/heartbeat.
-Run: wscat -c "$url"
+Run: wscat -c "$masked_url" (replace *** with your API key)
 Then send:
 $join
 And every ~30s:


### PR DESCRIPTION
## Problem

`scripts/opensea-stream-collection.sh` leaked the `OPENSEA_API_KEY` in two ways:

1. The `wscat` fallback printed the full WebSocket URL (including `?token=<key>`) to **stdout**
2. The wscat instructions were written to stdout (not stderr), so they could be captured by pipes or logs

## Fix

- **Masked URL for display**: Added `masked_url` variable that replaces the token with `***` — used in any user-visible output
- **wscat fallback**: Now prints the masked URL instead of the real token, and redirects output to **stderr** so it won't leak into piped output
- **websocat path**: Added an informational `Connecting to Stream API...` message to stderr (no token)
- **No functional change**: The actual WebSocket connection still passes the real token in the URL as required by the Phoenix socket protocol

### Why URL-based auth remains

The OpenSea Stream API uses Phoenix channels, which authenticate via a `?token=` query parameter. Header-based auth is not supported for this WebSocket protocol. The fix ensures the token value is never printed to stdout or stderr.

Resolves: DIS-86

Link to Devin session: https://app.devin.ai/sessions/bc9a746ee28f4c18aa5c0fe2d43a0922
Requested by: @ckorhonen